### PR TITLE
Updates for Django 4

### DIFF
--- a/docs/sections/scopesclaims.rst
+++ b/docs/sections/scopesclaims.rst
@@ -82,7 +82,7 @@ Somewhere in your Django ``settings.py``::
 
 Inside your oidc_provider_settings.py file add the following class::
 
-    from django.utils.translation import ugettext as _
+    from django.utils.translation import gettext as _
     from oidc_provider.lib.claims import ScopeClaims
 
     class CustomScopeClaims(ScopeClaims):

--- a/oidc_provider/admin.py
+++ b/oidc_provider/admin.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 
 from django.forms import ModelForm
 from django.contrib import admin
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from oidc_provider.models import Client, Code, Token, RSAKey
 

--- a/oidc_provider/lib/claims.py
+++ b/oidc_provider/lib/claims.py
@@ -1,6 +1,6 @@
 import copy
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from oidc_provider import settings
 

--- a/oidc_provider/migrations/0007_auto_20160111_1844.py
+++ b/oidc_provider/migrations/0007_auto_20160111_1844.py
@@ -3,8 +3,9 @@
 from __future__ import unicode_literals
 
 import datetime
+from datetime import timezone
+
 from django.db import migrations, models
-from django.utils.timezone import utc
 
 
 class Migration(migrations.Migration):
@@ -30,7 +31,7 @@ class Migration(migrations.Migration):
             model_name='client',
             name='date_created',
             field=models.DateField(
-                auto_now_add=True, default=datetime.datetime(2016, 1, 11, 18, 44, 32, 192477, tzinfo=utc)),
+                auto_now_add=True, default=datetime.datetime(2016, 1, 11, 18, 44, 32, 192477, tzinfo=timezone.utc)),
             preserve_default=False,
         ),
         migrations.AlterField(

--- a/oidc_provider/migrations/0016_userconsent_and_verbosenames.py
+++ b/oidc_provider/migrations/0016_userconsent_and_verbosenames.py
@@ -3,10 +3,11 @@
 from __future__ import unicode_literals
 
 import datetime
+from datetime import timezone
+
 from django.conf import settings
 from django.db import migrations, models
 import django.db.models.deletion
-from django.utils.timezone import utc
 
 
 class Migration(migrations.Migration):
@@ -20,7 +21,7 @@ class Migration(migrations.Migration):
             model_name='userconsent',
             name='date_given',
             field=models.DateTimeField(
-                default=datetime.datetime(2016, 6, 10, 17, 53, 48, 889808, tzinfo=utc), verbose_name='Date Given'),
+                default=datetime.datetime(2016, 6, 10, 17, 53, 48, 889808, tzinfo=timezone.utc), verbose_name='Date Given'),
             preserve_default=False,
         ),
         migrations.AlterField(

--- a/oidc_provider/models.py
+++ b/oidc_provider/models.py
@@ -6,7 +6,7 @@ import json
 
 from django.db import models
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.conf import settings
 
 

--- a/oidc_provider/signals.py
+++ b/oidc_provider/signals.py
@@ -2,5 +2,8 @@
 from django.dispatch import Signal
 
 
-user_accept_consent = Signal(providing_args=['user', 'client', 'scope'])
-user_decline_consent = Signal(providing_args=['user', 'client', 'scope'])
+# Signal provides the arguments 'user', 'client', 'scope'
+user_accept_consent = Signal()
+
+# Signal provides the arguments 'user', 'client', 'scope'
+user_decline_consent = Signal()

--- a/oidc_provider/version.py
+++ b/oidc_provider/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.7.0-orm'
+__version__ = '0.7.0-orm.1'


### PR DESCRIPTION
- Changed `ugettext*` to `gettext*` (https://docs.djangoproject.com/en/4.1/releases/4.0/#features-removed-in-4-0)
- Moved providing args to docs (https://docs.djangoproject.com/en/4.0/releases/3.1/#id2)
- Switch `django.utils.timezone.utc` to `datetime.timezone.utc` (https://docs.djangoproject.com/en/4.1/releases/4.0/#miscellaneous)