### PR TITLE
UA-3234 | Part 2, now with Py3.8 support

### DIFF
--- a/oidc_provider/models.py
+++ b/oidc_provider/models.py
@@ -1,6 +1,7 @@
 import base64
 import binascii
-from hashlib import md5, sha256
+import hashlib
+from hashlib import sha256
 import json
 
 from django.db import models
@@ -264,5 +265,7 @@ class RSAKey(models.Model):
     @property
     def kid(self):
         return u'{0}'.format(
-            md5(self.key.encode('utf-8'), usedforsecurity=False).hexdigest() if self.key else ''
+            hashlib.new("md5", self.key.encode('utf-8'), usedforsecurity=False).hexdigest()
+            if self.key
+            else ''
         )


### PR DESCRIPTION
My first attempt at this failed because Py3.8 hashlib.md5 doesn't have a `usedforsecurity` argument. `hashlib.new` will ignore `kwargs` which do not exist. So I've switched to using that.

Also tested with py3.8 (was doing 3.9 - 3.11) but it's always that one you didn't look at. Now I'm sure all tests pass on all version combinations. 😒 

