### PR TITLE
UA-3350 | increased log level

### DIFF
--- a/oidc_provider/lib/endpoints/token.py
+++ b/oidc_provider/lib/endpoints/token.py
@@ -155,7 +155,7 @@ class TokenEndpoint(object):
                 if scope_requested in self.client.scope:
                     token_scopes.append(scope_requested)
                 else:
-                    logger.debug('[Token] The request scope %s is not supported by client %s',
+                    logger.error('[Token] The request scope %s is not supported by client %s',
                                  scope_requested, self.client.client_id)
                     raise TokenError('invalid_scope')
         # if no scopes requested assign client's scopes

--- a/oidc_provider/version.py
+++ b/oidc_provider/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.8.2+orm'
+__version__ = '0.8.3+orm'


### PR DESCRIPTION
Bump'd logging up from `.debug` to `.error` for failures in `validate_requested_scopes`. This is where `django-oidc-provider` blows up (when it does), due to missing scope(s) on the `oidc_provider.models.Client`. 

Were hoping to be able to track failures and `fix the data` of the `Client`'s rather than patch the code. 🤞 