### PR TITLE
UA-4242 | Add `scopes_supported` field w/ default set to `["openid"]`

### DIFF
--- a/oidc_provider/settings.py
+++ b/oidc_provider/settings.py
@@ -214,6 +214,13 @@ class DefaultSettings(object):
         """
         return False
 
+    @property
+    def OIDC_SCOPES_SUPPORTED(self):
+        """
+        OPTIONAL: A list of scopes supported by the OP.
+        """
+        return ['openid']
+
 
 default_settings = DefaultSettings()
 

--- a/oidc_provider/version.py
+++ b/oidc_provider/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.8.3+orm.1'
+__version__ = '0.8.3+orm.2'

--- a/oidc_provider/views.py
+++ b/oidc_provider/views.py
@@ -300,6 +300,9 @@ class ProviderInfoView(View):
         if settings.get("OIDC_SESSION_MANAGEMENT_ENABLE"):
             dic["check_session_iframe"] = site_url + reverse("oidc_provider:check-session-iframe")
 
+        if settings.get('OIDC_SCOPES_SUPPORTED'):
+            dic['scopes_supported'] = settings.get('OIDC_SCOPES_SUPPORTED')
+
         return dic
 
     def _build_cache_key(self, request):


### PR DESCRIPTION
While the [OIDC spec](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata) says the `scopes_supported`  field should be optional, some clients (such as Oracle) do not adhere to the spec and require it.