### PR TITLE
UA-4502 | Log token endpoint errors

### DIFF
--- a/oidc_provider/version.py
+++ b/oidc_provider/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.8.3+orm.2'
+__version__ = "0.8.3+orm.3"


### PR DESCRIPTION
There are many ways in which token requests can fail. Here we add logs wherever a `TokenError` is raised. Logging these errors has two benefits:

1. Helps troubleshoot PKCE integration
2. Allows us to set up monitors to reveal user auth issues or bad actor shenanigans 

The downside is that this could add friction during upstream merges, but hopefully this will merge cleanly